### PR TITLE
Fix #2: codespell-2.2.1

### DIFF
--- a/syntaxes/cmd-help.sublime-syntax
+++ b/syntaxes/cmd-help.sublime-syntax
@@ -27,7 +27,7 @@ variables:
 
 ### command/option argument variables:
   ellipsis: '\.\.\.'
-  allcaps_argument_name: '[A-Z][0-9A-Z_]*\b'
+  allcaps_argument_name: '[A-Z][0-9A-Z_-]*\b'
   relaxed_argument_name: '[A-Za-z][0-9A-Za-z_-]*\b'
 
 ### other-def variables:
@@ -69,7 +69,7 @@ scope_variables: # last scope is matched first
 
   # non all-caps definitions: subcommands, argument enums, etc.
   - &OTHER_DEF_SCOPES
-    keyword.other.def.cmd-help # support.fuction variable.function ?
+    keyword.other.def.cmd-help # support.function variable.function ?
 
   - &FILE_DEF_SCOPES
     constant.file.cmd-help

--- a/tests/highlighted/codespell-2.2.1.txt
+++ b/tests/highlighted/codespell-2.2.1.txt
@@ -21,7 +21,7 @@
 [38;2;248;248;242m                        corrections. If this flag is not specified or equals[0m
 [38;2;248;248;242m                        "-" then the default dictionary is used. This option[0m
 [38;2;248;248;242m                        can be specified multiple times.[0m
-[38;2;248;248;242m  [0m[38;2;166;226;46m--builtin[0m[38;2;248;248;242m [0m[38;2;253;151;31mBUILTIN[0m[38;2;248;248;242m-LIST[0m
+[38;2;248;248;242m  [0m[38;2;166;226;46m--builtin[0m[38;2;248;248;242m [0m[38;2;253;151;31mBUILTIN-LIST[0m
 [38;2;248;248;242m                        comma-separated list of builtin dictionaries to[0m
 [38;2;248;248;242m                        include (when "-D -" or no "-D" is passed). Current[0m
 [38;2;248;248;242m                        options are:[0m

--- a/tests/syntax/syntax_test_codespell.txt
+++ b/tests/syntax/syntax_test_codespell.txt
@@ -25,9 +25,7 @@ options:
                         "-" then the default dictionary is used. This option
                         can be specified multiple times.
   --builtin BUILTIN-LIST
-#           ^^^^^^^ variable.parameter.option-argument.cmd-help
-#                  ^^^^^ - variable.parameter.option-argument.cmd-help
-#todo: this should be scoped as option argument too, "-" shouldn't break it
+#           ^^^^^^^^^^^^ variable.parameter.option-argument.cmd-help
                         comma-separated list of builtin dictionaries to
                         include (when "-D -" or no "-D" is passed). Current
                         options are:


### PR DESCRIPTION
![Screenshot from 2022-10-04 15-46-36](https://user-images.githubusercontent.com/32936898/193763583-7a93174a-0e42-4d5e-ae1f-4e0c7f39a0e6.png)
