### PR TITLE
Check `bat` CI compliance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,3 +55,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run theme regression tests
         run: tests/theme_regression.sh
+
+  bat_ci_compliance:
+    name: Bat CI Compliance
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check bat CI compliance
+        run: scripts/check_bat_ci_compliance.sh

--- a/scripts/check_bat_ci_compliance.sh
+++ b/scripts/check_bat_ci_compliance.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+theirs=https://raw.githubusercontent.com/sharkdp/bat/refs/heads/master/tests/syntax-tests/highlighted/cmd-help/test.cmd-help
+ours=tests/highlighted/bat-short-0.22.1.txt
+theirs_copy=/tmp/bat-regression-test.cmd-help
+ours_basename=$(basename $ours)
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 9
+
+# Fetch regression test from `bat`
+curl --location --output $theirs_copy $theirs &> /dev/null
+curl_exit_status=$?
+if [ $curl_exit_status -ne 0 ]; then
+    echo "could not fetch the bat regression test, curl failed with code $curl_exit_status."
+    exit 1
+fi
+
+# check compliance with our regression test in bat CI
+if ! diff ../$ours $theirs_copy; then
+    cat <<EOF
+::warning file=$ours,title=Would fail bat CI::\
+The highlight changes to $ours_basename would fail CI in the bat project. For more details, see: \
+https://github.com/victor-gp/cmd-help-sublime-syntax/wiki/How-to-manually-bump-cmd%E2%80%90help-version-in-bat%27s-submodules
+EOF
+    exit 1
+else
+    echo "ok: $ours matches the version for bat CI"
+fi


### PR DESCRIPTION
Bat tracks syntax regressions with a test file for each syntax. In our
case, that sample file is the short help for bat v0.22.1.

We already tracked that sample in our own highlight regression tests,
but now we make this check more explicit through an extra job in our
GitHub Actions CI.

This new job doesn't fail the whole CI workflow, but emits a warning
when our highlight for this sample differs from the one in bat. Then it
links our docs with the explanation on why/how to update the regression
test in the bat project.